### PR TITLE
Fixed document updating

### DIFF
--- a/document_resource.go
+++ b/document_resource.go
@@ -158,21 +158,14 @@ func (d *DocumentResource) deleteDocument(req *restful.Request, resp *restful.Re
 	col := d.getMongoCollection(req, session)
 	id := req.PathParameter("_id")
 
-	var delerr error
 	if bson.IsObjectIdHex(id) {
-		delerr = col.RemoveId(bson.ObjectIdHex(id))
+		err = col.RemoveId(bson.ObjectIdHex(id))
 	} else {
-		delerr = col.Remove(bson.M{"_id": id})
+		err = col.Remove(bson.M{"_id": id})
 	}
-
-	// TODO crackcomm
-	//err = col.Remove(bson.M{"_id": bson.ObjectIdHex(id)})
-	//if err != nil && err.String() == "not found" {
-	//	err = col.Remove(bson.M{"_id": id}) // sometimes it happens that id is not ObjectId
-	//}
-
-	if delerr != nil {
-		handleError(delerr, resp)
+	
+	if err != nil {
+		handleError(err, resp)
 		return
 	}
 	resp.WriteHeader(http.StatusOK)


### PR DESCRIPTION
If document ID in database is stored as ObjectIdHex it should be also in query (especially while updating so it won't be necessary to use [this](https://github.com/crackcomm/mora/blob/f71bcb2df43e29cd8db8d1badf481d48d962bd17/document_resource.go#L168)).
While updating document, stored ObjectIdHex `_id` field won't match string `_id` field in the query and new document will be created.
