### PR TITLE
Fixed document Update. (second argument is not just document)

### DIFF
--- a/document_resource.go
+++ b/document_resource.go
@@ -233,14 +233,15 @@ func (d *DocumentResource) putDocument(req *restful.Request, resp *restful.Respo
 	col := d.getMongoCollection(req, session)
 	doc := bson.M{}
 	req.ReadEntity(&doc)
-	// Apply internal _id
-	newId := req.PathParameter("_id")
-	if bson.IsObjectIdHex(newId) {
-		doc["_id"] = bson.ObjectIdHex(newId)
+	// Create selector with id
+	var id interface{}
+	if strId := req.PathParameter("_id"); bson.IsObjectIdHex(strId) {
+		id = bson.ObjectIdHex(strId)
 	} else {
-		doc["_id"] = newId
+		id = strId
 	}
-	_, err = col.Upsert(bson.M{"_id": doc["_id"]}, doc)
+	sel := bson.M{"_id": id} // query selector
+	_, err = col.Upsert(sel, doc)
 	if err != nil {
 		handleError(err, resp)
 		return


### PR DESCRIPTION
When we are pushing `_id` (which we don't have to do) we are automatically make it impossible to use "atomic" MongoDB [Update Methods](http://docs.mongodb.org/manual/reference/operator/nav-update/#id1).

Error which occurs when trying to establish some changes in document using `$set` field:

> Invalid modifier specified: _id
