### PR TITLE
Fixed atomic document Update.

### DIFF
--- a/document_resource.go
+++ b/document_resource.go
@@ -233,19 +233,21 @@ func (d *DocumentResource) putDocument(req *restful.Request, resp *restful.Respo
 	col := d.getMongoCollection(req, session)
 	doc := bson.M{}
 	req.ReadEntity(&doc)
-	// Apply internal _id
-	newId := req.PathParameter("_id")
-	if bson.IsObjectIdHex(newId) {
-		doc["_id"] = bson.ObjectIdHex(newId)
+	// Create selector with id
+	var id interface{}
+	strId := req.PathParameter("_id")
+	if bson.IsObjectIdHex(strId) {
+		id = bson.ObjectIdHex(strId)
 	} else {
-		doc["_id"] = newId
+		id = strId
 	}
-	_, err = col.Upsert(bson.M{"_id": doc["_id"]}, doc)
+	sel := bson.M{"_id": id} // query selector
+	_, err = col.Upsert(sel, doc)
 	if err != nil {
 		handleError(err, resp)
 		return
 	}
-	d.handleCreated(req, resp, newId)
+	d.handleCreated(req, resp, strId)
 }
 
 // A document cannot have an _id set. Use PUT in that case


### PR DESCRIPTION
When we are pushing `_id` (which we don't have to do) we are automatically make it impossible to use "atomic" MongoDB [Update Methods](http://docs.mongodb.org/manual/reference/operator/nav-update/#id1).

Error which occurs when trying to establish some changes in document using `$set` field:

For example:

```
{
    "$set": {
        "type": "super"
    }
}
```

It should set field `type` to value `super` but error occurs:

> Invalid modifier specified: _id
