### PR TITLE
The correct location of the document for every route.

### DIFF
--- a/document_resource.go
+++ b/document_resource.go
@@ -275,7 +275,10 @@ func (d *DocumentResource) postDocument(req *restful.Request, resp *restful.Resp
 }
 
 func (d *DocumentResource) handleCreated(req *restful.Request, resp *restful.Response, id string) {
-	location := strings.TrimRight(req.Request.URL.RequestURI(), "/") + "/" + id
+	location := strings.TrimRight(req.Request.URL.RequestURI(), "/")
+	if noid := strings.TrimRight(location, id); noid == location {
+		location = noid + "/" + id
+	}
 	resp.AddHeader("Content-Location", location)
 	resp.WriteHeader(http.StatusCreated)
 }


### PR DESCRIPTION
It works with both `/docs/alias/db/col` (when creating) and `/docs/alias/db/col/id` (when updating or creating) now.

It fixed location of modified object in `Content-Location` header when document was updated with `putDocument` operation.

> Request Url: http://127.0.0.1:8181/docs/local/use1/webservices/52519954b734f9036c000001
> Request Method: PUT
> 
> Status Code: 201
> ...
> Content-Location: /docs/local/use1/webservices/52519954b734f9036c000001/52519954b734f9036c000001
