### PR TITLE
Fix EOF errors when the mongo database gets disconnected

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -56,7 +56,7 @@ func (s *SessionManager) Get(alias string) (*mgo.Session, bool, error) {
 
 	// Clone and return if sessions exists
 	if existing != nil {
-		return existing.Clone(), true, nil
+		return existing.Copy(), true, nil
 	}
 
 	// Get timeout from configuration


### PR DESCRIPTION
Instead of calling Clone on existing sessions, we now call Copy, which
will acquire a new session from the pool and reconnect if necessary.
This prevents disconnected sockets from being reused if the mongo server
gets disconnected and also handles a new master server being elected
when part of a replicaset.

See:
https://github.com/go-mgo/mgo/issues/49#issuecomment-65122720
https://github.com/go-mgo/mgo/issues/47#issuecomment-63368722