### PR TITLE
Allow connecting to replica sets via a connection URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,9 @@ Mora uses a simple properties file to specify host,port,aliases and other option
 	mongod.{alias}.username=
 	mongod.{alias}.password=
 	mongod.{alias}.database=
+	# alternatively, a mongodb connection string uri can be used instead
+	# supported options: http://godoc.org/labix.org/v2/mgo#Dial
+	mongod.{alias}.uri=mongodb://myuser:mypass@localhost:40001,otherhost:40001/mydb
 
 	# enable /stats/ endpoint
 	mora.statistics.enable=true


### PR DESCRIPTION
This seemed like the easiest way to allow connections to replicasets,
since all the different host options can be wrapped up in the single
`uri` option that accepts the standard MongoDB connection URI sytnax:
http://godoc.org/labix.org/v2/mgo#Dial