### PR TITLE
Fix all numbers inserted or updated becoming strings

### DIFF
--- a/api/documents/handlers.go
+++ b/api/documents/handlers.go
@@ -105,7 +105,9 @@ func (d *Resource) DatabaseCollectionsHandler(req *restful.Request, resp *restfu
 func (d *Resource) CollectionUpdateHandler(req *restful.Request, resp *restful.Response) {
 	// Read a document from request
 	document := bson.M{}
-	if err := req.ReadEntity(&document); err != nil {
+	decoder := json.NewDecoder(req.Request.Body)
+	err := decoder.Decode(&document)
+	if err != nil {
 		WriteStatusError(http.StatusBadRequest, err, resp)
 		return
 	}

--- a/api/documents/handlers.go
+++ b/api/documents/handlers.go
@@ -105,6 +105,10 @@ func (d *Resource) DatabaseCollectionsHandler(req *restful.Request, resp *restfu
 func (d *Resource) CollectionUpdateHandler(req *restful.Request, resp *restful.Response) {
 	// Read a document from request
 	document := bson.M{}
+	// Handle JSON parsing manually here, instead of relying on go-restful's
+	// req.ReadEntity. This is because ReadEntity currently parses JSON with
+	// UseNumber() which turns all numbers into strings. See:
+	// https://github.com/emicklei/mora/pull/31
 	decoder := json.NewDecoder(req.Request.Body)
 	err := decoder.Decode(&document)
 	if err != nil {


### PR DESCRIPTION
The parsing of the JSON body was being handled by go-restful, which uses the JSON `decoder.UseNumber()` method. This parses all numbers as strings instead of integers or floats, which makes it impossible to insert or update numeric values with mora. By handling the JSON parsing locally, we can skip UseNumber, so integers and floats remain as those native types.

See: https://github.com/emicklei/go-restful/blob/v1.1.3/request.go#L112-L114