### PR TITLE
Use Mongo Extended JSON spec for outputing and querying BSON types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ When querying on collections those parameters are available:
 	skip   - offset in the result set
 	fields - comma separated list of (path-dotted) field names
 	sort   - comma separated list of (path-dotted) field names
+	extended_json - set to "true" to return responses in [MongoDB Extended JSON](http://docs.mongodb.org/manual/reference/mongodb-extended-json/) format
 
 ##### Examples
 

--- a/api/documents/handlers.go
+++ b/api/documents/handlers.go
@@ -289,10 +289,15 @@ func (d *Resource) CollectionFindHandler(req *restful.Request, resp *restful.Res
 			WriteError(err, resp)
 			return
 		}
-		jsonDocument, err := mejson.Marshal(document)
-		if err != nil {
-			WriteError(err, resp)
-			return
+		var jsonDocument interface{}
+		if req.QueryParameter("extended_json") == "true" {
+			jsonDocument, err = mejson.Marshal(document)
+			if err != nil {
+				WriteError(err, resp)
+				return
+			}
+		} else {
+			jsonDocument = document
 		}
 		WriteResponse(jsonDocument, resp)
 		return
@@ -306,10 +311,15 @@ func (d *Resource) CollectionFindHandler(req *restful.Request, resp *restful.Res
 		return
 	}
 
-	jsonDocuments, err := mejson.Marshal(documents)
-	if err != nil {
-		WriteError(err, resp)
-		return
+	var jsonDocuments interface{}
+	if req.QueryParameter("extended_json") == "true" {
+		jsonDocuments, err = mejson.Marshal(documents)
+		if err != nil {
+			WriteError(err, resp)
+			return
+		}
+	} else {
+		jsonDocuments = documents
 	}
 
 	res := struct {
@@ -408,6 +418,7 @@ func (d *Resource) CollectionRemoveHandler(req *restful.Request, resp *restful.R
 // Param(ws.QueryParameter("skip", "number of documents to skip in the result set, default=0")).
 // Param(ws.QueryParameter("limit", "maximum number of documents in the result set, default=10")).
 // Param(ws.QueryParameter("sort", "comma separated list of field names")).
+// Param(ws.QueryParameter("extended_json", "set to "true" to return responses in MongoDB Extended JSON format, default=false")).
 //
 func (d *Resource) ComposeQuery(col *mgo.Collection, req *restful.Request) (query *mgo.Query, one bool, err error) {
 	// Get selector from `_id` path parameter and `query` query parameter

--- a/api/statistics/handlers.go
+++ b/api/statistics/handlers.go
@@ -5,7 +5,7 @@ import (
 	"github.com/emicklei/go-restful"
 	. "github.com/emicklei/mora/api/response"
 	"github.com/emicklei/mora/session"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // Statistics Resource

--- a/session/session.go
+++ b/session/session.go
@@ -3,7 +3,7 @@ package session
 import (
 	"errors"
 	"github.com/emicklei/goproperties"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 	"log"
 	"strconv"
 	"strings"


### PR DESCRIPTION
This standardizes how complex BSON data types (like ObjectId, date fields, binary data, etc) get translated to JSON. It uses MongoDB's [extended JSON specification](http://docs.mongodb.org/manual/reference/mongodb-extended-json/): The heavy lifting is done by the [mejson](https://github.com/compose/mejson) go library.

By treating the input queries as extended JSON, this allows for several types of queries that weren't previously possible. For example, it's now possible to query a date field like:

```
?query={"updated_at":{"$gt":{"$date":1426411642889}}}
```

Other special BSON types should be queryable in a similar fashion.

However, the output is backwards incompatible, since these various BSON field types now have a different output style. For example, what might have previously been returned as:

```json
{
  "_id": "5505507a1c57d0372be0076c",
  "updated_at": "2015-03-15T09:27:22.889Z",
}
```

Is now returned as:

```json
{
  "_id": {
    "$oid": "5505507a1c57d0372be0076c"
  },
  "updated_at": {
    "$date": 1426411642889
  }
}
```

String and numeric fields are not affected by this and will still be returned the same.

The change in package paths for the mgo library as part of this commit are for compatibility with the mejson library (which uses the gopkg.in url instead of the github.com address).

Note, this pull request also includes the commit to fix number handling from #31. That was included in this pull request too, since the number fixes are needed to properly handle the things like date parsing (since those are all treated as integers).