### PR TITLE
Add support for setting read consistency mode on sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,11 @@ Mora uses a simple properties file to specify host,port,aliases and other option
 	mongod.{alias}.username=
 	mongod.{alias}.password=
 	mongod.{alias}.database=
+	# read preference mode
+	# supported options (case-insensitive): https://godoc.org/gopkg.in/mgo.v2#Mode
+	mongod.{alias}.mode=primary
 	# alternatively, a mongodb connection string uri can be used instead
-	# supported options: http://godoc.org/labix.org/v2/mgo#Dial
+	# supported options: https://godoc.org/gopkg.in/mgo.v2#Dial
 	mongod.{alias}.uri=mongodb://myuser:mypass@localhost:40001,otherhost:40001/mydb
 
 	# enable /stats/ endpoint

--- a/session/session.go
+++ b/session/session.go
@@ -98,6 +98,30 @@ func (s *SessionManager) Get(alias string) (*mgo.Session, bool, error) {
 		info("unable to connect to [%s] because:%v", sessionId, err)
 		newSession = nil
 	} else {
+		var mode = strings.ToLower(config.GetString("mode", ""))
+		if mode != "" {
+			switch mode {
+			case "primary":
+				newSession.SetMode(mgo.Primary, true)
+			case "primarypreferred":
+				newSession.SetMode(mgo.PrimaryPreferred, true)
+			case "secondary":
+				newSession.SetMode(mgo.Secondary, true)
+			case "secondarypreferred":
+				newSession.SetMode(mgo.SecondaryPreferred, true)
+			case "nearest":
+				newSession.SetMode(mgo.Nearest, true)
+			case "eventual":
+				newSession.SetMode(mgo.Eventual, true)
+			case "monotonic":
+				newSession.SetMode(mgo.Monotonic, true)
+			case "strong":
+				newSession.SetMode(mgo.Strong, true)
+			default:
+				info("Unknown 'mode' configuration value: %s", mode)
+			}
+		}
+
 		s.sessions[sessionId] = newSession
 	}
 	s.accessLock.Unlock()


### PR DESCRIPTION
This adds support for calling SetMode on the session, which allows for choosing different read preferences (secondary, nearest, etc).

This also makes a small adjustment to point to the latest version of mgo's Dial documentation in the README's uri reference.